### PR TITLE
UI Bug fix and Making Side Door Counter have hinge

### DIFF
--- a/OP_ChopChop!/Assets/OccAssets/OccAssets Prefabs/UI Prefabs/OrderInventoryUI/~ShopManager.prefab
+++ b/OP_ChopChop!/Assets/OccAssets/OccAssets Prefabs/UI Prefabs/OrderInventoryUI/~ShopManager.prefab
@@ -258,11 +258,11 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1079899664222989491}
   m_LocalRotation: {x: -0.0000000037252899, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.17494814, y: 0.110030256, z: 0.11003029}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7920102737914875042}
+  m_Father: {fileID: 3139668400525543563}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -668,7 +668,7 @@ RectTransform:
   - {fileID: 7829021206883875298}
   - {fileID: 8989936703189028911}
   - {fileID: 1117073816415139141}
-  - {fileID: 7920102737914875042}
+  - {fileID: 3139668400525543563}
   m_Father: {fileID: 7156260249628498118}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1176,7 +1176,7 @@ RectTransform:
   m_LocalScale: {x: 0.17494814, y: 0.110030256, z: 0.11003029}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7920102737914875042}
+  m_Father: {fileID: 3139668400525543563}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -1347,7 +1347,7 @@ RectTransform:
   m_LocalScale: {x: 0.17494814, y: 0.110030256, z: 0.11003029}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7920102737914875042}
+  m_Father: {fileID: 3139668400525543563}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -2465,6 +2465,12 @@ MonoBehaviour:
   _txtSalmonPrice: {fileID: 8946947378307029268}
   _txtTunaPrice: {fileID: 7318283706988463373}
   _txtPlayerMoney: {fileID: 7208262895775594932}
+  _salmonSlabs: []
+  _tunaSlabs: []
+  interactableButtons:
+  - {fileID: 1696801737730508055}
+  - {fileID: 4379672902651748861}
+  - {fileID: 5340195205307591855}
 --- !u!1 &7633227258215998624
 GameObject:
   m_ObjectHideFlags: 0
@@ -3146,7 +3152,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7920102737914875042}
+  - component: {fileID: 3139668400525543563}
   m_Layer: 5
   m_Name: ----BuyButtons-------
   m_TagString: Untagged
@@ -3154,15 +3160,15 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &7920102737914875042
-RectTransform:
+--- !u!4 &3139668400525543563
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8988328029794740744}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.59999335}
+  m_LocalPosition: {x: -37.39, y: 0.3, z: 0.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -3172,8 +3178,3 @@ RectTransform:
   m_Father: {fileID: 1005307402177500913}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -37.39, y: 0.3000021}
-  m_SizeDelta: {x: 17.514814, y: 44.203026}
-  m_Pivot: {x: 0.5, y: 0.5}

--- a/OP_ChopChop!/Assets/Scenes/MainGameScene.unity
+++ b/OP_ChopChop!/Assets/Scenes/MainGameScene.unity
@@ -216,12 +216,15 @@ GameObject:
   - component: {fileID: 99775474}
   - component: {fileID: 99775476}
   - component: {fileID: 99775475}
+  - component: {fileID: 99775477}
+  - component: {fileID: 99775478}
+  - component: {fileID: 99775479}
   m_Layer: 0
   m_Name: side counter door (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 2147483647
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!4 &99775474
 Transform:
@@ -288,6 +291,71 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 99775473}
   m_Mesh: {fileID: 6249202974098014557, guid: 95ee6848bdaa6484d9644c85af64d5b8, type: 3}
+--- !u!65 &99775477
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 99775473}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6195703, y: 0.12036094, z: 0.8928889}
+  m_Center: {x: 0.31482664, y: -0.060180515, z: -0.44644672}
+--- !u!54 &99775478
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 99775473}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 2
+--- !u!59 &99775479
+HingeJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 99775473}
+  m_ConnectedBody: {fileID: 0}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0.3, y: 0, z: 0}
+  m_Axis: {x: 1, y: 0, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0.53, z: 0}
+  m_UseSpring: 0
+  m_Spring:
+    spring: 0
+    damper: 0
+    targetPosition: 0
+  m_UseMotor: 0
+  m_Motor:
+    targetVelocity: 0
+    force: 0
+    freeSpin: 0
+  m_UseLimits: 1
+  m_Limits:
+    min: 0.96287537
+    max: 88.28385
+    bounciness: 0
+    bounceMinVelocity: 0.2
+    contactDistance: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!1001 &127534066
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7066,7 +7134,6 @@ GameObject:
   - component: {fileID: 1872203303}
   - component: {fileID: 1872203302}
   - component: {fileID: 1872203301}
-  - component: {fileID: 1872203308}
   m_Layer: 0
   m_Name: XR Origin (VR)
   m_TagString: Untagged
@@ -7170,7 +7237,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1872203299}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0bf296fc962d7184ab14ad1841598d5f, type: 3}
   m_Name: 
@@ -7253,73 +7320,6 @@ MonoBehaviour:
   m_CameraFloorOffsetObject: {fileID: 209618304}
   m_RequestedTrackingOriginMode: 1
   m_CameraYOffset: 1.6
---- !u!114 &1872203308
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1872203299}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0924bcaa9eb50df458a783ae0e2b59f5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 0}
-  m_InteractionLayerMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_InteractionLayers:
-    m_Bits: 4294967295
-  m_AttachTransform: {fileID: 0}
-  m_KeepSelectedTargetValid: 1
-  m_DisableVisualsWhenBlockedInGroup: 1
-  m_StartingSelectedInteractable: {fileID: 0}
-  m_StartingTargetFilter: {fileID: 0}
-  m_HoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_HoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_SelectEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_SelectExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_StartingHoverFilters: []
-  m_StartingSelectFilters: []
-  m_OnHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelectEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelectExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_PokeDepth: 0.1
-  m_PokeWidth: 0.0075
-  m_PokeSelectWidth: 0.015
-  m_PokeHoverRadius: 0.015
-  m_PokeInteractionOffset: 0.005
-  m_PhysicsLayerMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_PhysicsTriggerInteraction: 1
-  m_RequirePokeFilter: 1
-  m_EnableUIInteraction: 1
-  m_DebugVisualizationsEnabled: 0
-  m_UIHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_UIHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1 &1923682892
 GameObject:
   m_ObjectHideFlags: 0
@@ -7544,7 +7544,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   CustomersServed: 0
-  _startingPlayerMoney: 0
+  _startingPlayerMoney: 1000
   _endOfDayReceipt: {fileID: 0}
 --- !u!1 &2030309113
 GameObject:

--- a/OP_ChopChop!/Assets/Scenes/TrainingScene.unity
+++ b/OP_ChopChop!/Assets/Scenes/TrainingScene.unity
@@ -2298,7 +2298,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 409879230}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0bf296fc962d7184ab14ad1841598d5f, type: 3}
   m_Name: 
@@ -3166,12 +3166,15 @@ GameObject:
   - component: {fileID: 485324184}
   - component: {fileID: 485324186}
   - component: {fileID: 485324185}
+  - component: {fileID: 485324187}
+  - component: {fileID: 485324188}
+  - component: {fileID: 485324189}
   m_Layer: 0
   m_Name: side counter door (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 2147483647
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!4 &485324184
 Transform:
@@ -3238,6 +3241,71 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485324183}
   m_Mesh: {fileID: 6249202974098014557, guid: 95ee6848bdaa6484d9644c85af64d5b8, type: 3}
+--- !u!65 &485324187
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 485324183}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6195703, y: 0.12036094, z: 0.8966347}
+  m_Center: {x: 0.31482664, y: -0.06018041, z: -0.44832045}
+--- !u!54 &485324188
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 485324183}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!59 &485324189
+HingeJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 485324183}
+  m_ConnectedBody: {fileID: 0}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0.00000011920929, z: 0}
+  m_Axis: {x: 1, y: 0, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0, z: 0}
+  m_UseSpring: 0
+  m_Spring:
+    spring: 0
+    damper: 0
+    targetPosition: 0
+  m_UseMotor: 0
+  m_Motor:
+    targetVelocity: 0
+    force: 0
+    freeSpin: 0
+  m_UseLimits: 1
+  m_Limits:
+    min: 0
+    max: 89.67888
+    bounciness: 0
+    bounceMinVelocity: 0.2
+    contactDistance: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!1 &535693111
 GameObject:
   m_ObjectHideFlags: 0

--- a/OP_ChopChop!/Assets/_Scripts/Managers/Game Handlers/GameManager.cs
+++ b/OP_ChopChop!/Assets/_Scripts/Managers/Game Handlers/GameManager.cs
@@ -113,6 +113,7 @@ public class GameManager : Singleton<GameManager>
     }
     public void DeductMoney(float amt)
     {
+        Debug.Log("Minus Player Money");
         if (amt < 0f) return;
 
         CurrentPlayerMoney -= amt;

--- a/OP_ChopChop!/Assets/_Scripts/Managers/Game Handlers/ShopManager.cs
+++ b/OP_ChopChop!/Assets/_Scripts/Managers/Game Handlers/ShopManager.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
+using System.Collections;
+using UnityEngine.UI;
+using System;
 
 public class ShopManager : Singleton<ShopManager> 
 {
@@ -20,6 +23,9 @@ public class ShopManager : Singleton<ShopManager>
     [SerializeField] TextMeshProUGUI _txtPlayerMoney;
 
     [SerializeField] List<GameObject> _salmonSlabs, _tunaSlabs;
+
+    [Header("Button")]
+    [SerializeField] private Button[] interactableButtons;
 
     public const int MAX_ORDER_COUNT = 3;
 
@@ -42,9 +48,21 @@ public class ShopManager : Singleton<ShopManager>
         _tunaSlabs = new List<GameObject>();
     }
 
-#endregion
+    #endregion
 
-#region Buying
+    #region Debugging code for button
+    /*
+    private void Update()
+    {
+        if(Input.GetKeyDown(KeyCode.W)) 
+        { 
+            BuySalmon();
+        }
+    }
+    */
+    #endregion
+
+    #region Buying
 
     public void BuySalmon()
     {
@@ -54,6 +72,11 @@ public class ShopManager : Singleton<ShopManager>
         GameObject salmon = SpawnManager.Instance.SpawnObject(_salmonPrefab,
                                                                  _salmonTransform.transform,
                                                                  SpawnObjectType.INGREDIENT);
+
+        StartCoroutine(ButtonCooldownTimer(0));
+
+        _txtPlayerMoney.text = GameManager.Instance.CurrentPlayerMoney.ToString();
+
         _salmonSlabs.Add(salmon);
     }
     public void BuyTuna()
@@ -64,6 +87,11 @@ public class ShopManager : Singleton<ShopManager>
         GameObject tuna = SpawnManager.Instance.SpawnObject(_tunaPrefab,
                                                             _tunaTransform.transform,
                                                             SpawnObjectType.INGREDIENT);
+        
+        StartCoroutine(ButtonCooldownTimer(1));
+       
+        _txtPlayerMoney.text = GameManager.Instance.CurrentPlayerMoney.ToString();
+
         _tunaSlabs.Add(tuna);
     }
     public void BuyRice()
@@ -71,13 +99,24 @@ public class ShopManager : Singleton<ShopManager>
         GameManager.Instance.DeductMoney(_ricePrice);
         Debug.LogError("Rice spanwing hasn't been added yet!");
 
+        StartCoroutine(ButtonCooldownTimer(2));
+
+        _txtPlayerMoney.text = GameManager.Instance.CurrentPlayerMoney.ToString();
+
         // insert code here to reset Rice at rice cooker
     }
 
     public void RemoveFromTunaList(GameObject obj) => _tunaSlabs.Remove(obj);
     public void RemoveFromSalmonList(GameObject obj) => _salmonSlabs.Remove(obj);
 
+    private IEnumerator ButtonCooldownTimer(int index)
+    {
+        interactableButtons[index].interactable = false;
 
+        yield return new WaitForSeconds(2f);
+
+        interactableButtons[index].interactable = true;
+    }
 
 
 


### PR DESCRIPTION
- Bug reported earlier:
  - CurrentPlayerMoney not being updated on the UI of the ShopUI after buying an item
  - After buying an ingredient, 2 instances appear instead of one

- Fix applied:
  - _txtCurrentPlayerMoney was apparentlyy not being updated whenever we buy an item, so I added a line per button function to update it after pressing the button.
  - added an array variable of button to store in all the buttons of the ShopUI
     - created a CoRoutine that when activated, button.intertactable = false and wait for 2f seconds before button.intertactable = true. This essentially adds a cooldown timer to the button and prevents the bug from happening.

- New Stuff:
  - Added hinges to the side door to both MainScene and TrainingScene - All you need to do is push the side door up, not grab the side door