### PR TITLE
Rice Ordering, MGS TP fix, and Graphics API update

### DIFF
--- a/OP_ChopChop!/Assets/Scenes/MainGameScene.unity
+++ b/OP_ChopChop!/Assets/Scenes/MainGameScene.unity
@@ -561,7 +561,7 @@ Transform:
   - {fileID: 64242515}
   - {fileID: 439263852}
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &196182676
 PrefabInstance:
@@ -775,7 +775,7 @@ Transform:
   m_Children:
   - {fileID: 1023353408}
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &282752834
 GameObject:
@@ -835,6 +835,96 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5145c04fd959bc5408a79a2818847665, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &309819469
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2030309114}
+    m_Modifications:
+    - target: {fileID: 637955420998036028, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_Name
+      value: pf_TpFloor
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 4.01259
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.0424
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6851891511792500818, guid: d9bb0abda740e5247b6a60a869661786,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 3613839608882385316, guid: d9bb0abda740e5247b6a60a869661786, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: d9bb0abda740e5247b6a60a869661786, type: 3}
 --- !u!1 &312042809
 GameObject:
   m_ObjectHideFlags: 0
@@ -1332,6 +1422,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &531911715 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2336919477517887479, guid: d9bb0abda740e5247b6a60a869661786,
+    type: 3}
+  m_PrefabInstance: {fileID: 309819469}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &544115479
 GameObject:
   m_ObjectHideFlags: 0
@@ -1681,7 +1777,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 106.630005, y: 0, z: 0}
 --- !u!114 &689173837
 MonoBehaviour:
@@ -2119,7 +2215,7 @@ PrefabInstance:
     - target: {fileID: 2622024756028450185, guid: 8b4f93340f6c07d4ea819b263b3303d2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2622024756028450185, guid: 8b4f93340f6c07d4ea819b263b3303d2,
         type: 3}
@@ -2207,11 +2303,11 @@ GameObject:
   - component: {fileID: 824663048}
   - component: {fileID: 824663050}
   m_Layer: 0
-  m_Name: BoxTrigger
+  m_Name: rice_BoxTrigger
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 2147483647
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!4 &824663047
 Transform:
@@ -2225,7 +2321,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 870641218}
+  m_Father: {fileID: 2951508505226456420}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &824663048
@@ -2332,8 +2428,11 @@ MonoBehaviour:
       m_Calls: []
   _ricePrefab: {fileID: 5821176368316166534, guid: 2222bdfaa7d2bc44e92938ab59e05114,
     type: 3}
+  _riceMesh: {fileID: 7827703469180435027}
+  _riceSpwnCollider: {fileID: 824663046}
   _spawnpoint: {fileID: 824663047}
   _isTutorial: 0
+  _decrementHeightCount: 0.01
 --- !u!65 &824663049
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -2389,7 +2488,7 @@ PrefabInstance:
     - target: {fileID: 2951508506046743332, guid: 866565e8a80e26b4c9eecdf15876ed2c,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.977
+      value: 0.9882
       objectReference: {fileID: 0}
     - target: {fileID: 2951508506046743332, guid: 866565e8a80e26b4c9eecdf15876ed2c,
         type: 3}
@@ -2463,48 +2562,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7827703469933024275, guid: 866565e8a80e26b4c9eecdf15876ed2c,
         type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7827703469933024275, guid: 866565e8a80e26b4c9eecdf15876ed2c,
+        type: 3}
       propertyPath: m_StaticEditorFlags
-      value: 2147483647
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 866565e8a80e26b4c9eecdf15876ed2c, type: 3}
---- !u!1 &870641217 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6786887230358626773, guid: 866565e8a80e26b4c9eecdf15876ed2c,
-    type: 3}
-  m_PrefabInstance: {fileID: 870641216}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &870641218 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2951508506046743332, guid: 866565e8a80e26b4c9eecdf15876ed2c,
-    type: 3}
-  m_PrefabInstance: {fileID: 870641216}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &870641219 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7827703469933024275, guid: 866565e8a80e26b4c9eecdf15876ed2c,
-    type: 3}
-  m_PrefabInstance: {fileID: 870641216}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &870641220 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3454190378542940937, guid: 866565e8a80e26b4c9eecdf15876ed2c,
-    type: 3}
-  m_PrefabInstance: {fileID: 870641216}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &870641221 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5722392891316959377, guid: 866565e8a80e26b4c9eecdf15876ed2c,
-    type: 3}
-  m_PrefabInstance: {fileID: 870641216}
-  m_PrefabAsset: {fileID: 0}
 --- !u!54 &870641222
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 870641217}
+  m_GameObject: {fileID: 6786887231225057173}
   serializedVersion: 2
   m_Mass: 1
   m_Drag: 0
@@ -2520,7 +2594,7 @@ MeshCollider:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 870641219}
+  m_GameObject: {fileID: 7827703469180435027}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
@@ -2534,7 +2608,7 @@ MeshCollider:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 870641220}
+  m_GameObject: {fileID: 3454190378221776201}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
@@ -2548,7 +2622,7 @@ MeshCollider:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 870641221}
+  m_GameObject: {fileID: 5722392891109545681}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
@@ -2772,7 +2846,7 @@ Transform:
   - {fileID: 1275272430}
   - {fileID: 755570537}
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &931057281
 GameObject:
@@ -2804,7 +2878,7 @@ Transform:
   m_Children:
   - {fileID: 1855442632}
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &951437942
 PrefabInstance:
@@ -3517,7 +3591,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 14
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 51.57, y: 0, z: 0}
 --- !u!114 &1165219973
 MonoBehaviour:
@@ -4291,7 +4365,7 @@ PrefabInstance:
     - target: {fileID: 2622024756028450185, guid: 8b4f93340f6c07d4ea819b263b3303d2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 2622024756028450185, guid: 8b4f93340f6c07d4ea819b263b3303d2,
         type: 3}
@@ -4805,7 +4879,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 13
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 132.736, y: 0, z: 0}
 --- !u!114 &1622442949
 MonoBehaviour:
@@ -5278,7 +5352,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: -8.4, y: 0, z: 0}
 --- !u!114 &1689955458
 MonoBehaviour:
@@ -5549,7 +5623,7 @@ PrefabInstance:
     - target: {fileID: 2622024756028450185, guid: 8b4f93340f6c07d4ea819b263b3303d2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2622024756028450185, guid: 8b4f93340f6c07d4ea819b263b3303d2,
         type: 3}
@@ -5727,7 +5801,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 15
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1784324189
 MonoBehaviour:
@@ -5835,7 +5909,7 @@ MonoBehaviour:
   m_TeleportationProvider: {fileID: 0}
   m_MatchOrientation: 0
   m_MatchDirectionalInput: 0
-  m_TeleportTrigger: 3
+  m_TeleportTrigger: 1
   m_FilterSelectionByHitNormal: 0
   m_UpNormalToleranceDegrees: 30
   m_Teleporting:
@@ -6007,7 +6081,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1920960300
 MonoBehaviour:
@@ -6119,12 +6193,12 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 870641218}
+  - {fileID: 2951508505226456420}
   - {fileID: 1712819818}
   - {fileID: 663073994}
   - {fileID: 1978784253}
   m_Father: {fileID: 2030309114}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1974421141
 PrefabInstance:
@@ -6310,6 +6384,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1577026307}
+  - {fileID: 531911715}
   - {fileID: 807711032}
   - {fileID: 2081921610}
   - {fileID: 1454759799}
@@ -6413,7 +6488,7 @@ PrefabInstance:
     - target: {fileID: 2622024756028450185, guid: 8b4f93340f6c07d4ea819b263b3303d2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2622024756028450185, guid: 8b4f93340f6c07d4ea819b263b3303d2,
         type: 3}
@@ -6595,7 +6670,7 @@ PrefabInstance:
     - target: {fileID: 7156260249628498118, guid: 7a609331d762229458520779795f465a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7156260249628498118, guid: 7a609331d762229458520779795f465a,
         type: 3}
@@ -6652,6 +6727,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: ~ShopManager
       objectReference: {fileID: 0}
+    - target: {fileID: 8791498176419619017, guid: 7a609331d762229458520779795f465a,
+        type: 3}
+      propertyPath: _riceCooker
+      value: 
+      objectReference: {fileID: 6786887231225057173}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7a609331d762229458520779795f465a, type: 3}
 --- !u!1001 &1256221064347734642
@@ -6907,9 +6987,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 737eec0da604cd246bb199bd9ceda74c, type: 3}
+--- !u!4 &2951508505226456420 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2951508506046743332, guid: 866565e8a80e26b4c9eecdf15876ed2c,
+    type: 3}
+  m_PrefabInstance: {fileID: 870641216}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3454190378221776201 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3454190378542940937, guid: 866565e8a80e26b4c9eecdf15876ed2c,
+    type: 3}
+  m_PrefabInstance: {fileID: 870641216}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5722392891109545681 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5722392891316959377, guid: 866565e8a80e26b4c9eecdf15876ed2c,
+    type: 3}
+  m_PrefabInstance: {fileID: 870641216}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6786887231225057173 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6786887230358626773, guid: 866565e8a80e26b4c9eecdf15876ed2c,
+    type: 3}
+  m_PrefabInstance: {fileID: 870641216}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7256349895780895007 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7156260249628498118, guid: 7a609331d762229458520779795f465a,
     type: 3}
   m_PrefabInstance: {fileID: 568472804029911513}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7827703469180435027 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7827703469933024275, guid: 866565e8a80e26b4c9eecdf15876ed2c,
+    type: 3}
+  m_PrefabInstance: {fileID: 870641216}
   m_PrefabAsset: {fileID: 0}

--- a/OP_ChopChop!/Assets/_Scripts/Managers/Game Handlers/ShopManager.cs
+++ b/OP_ChopChop!/Assets/_Scripts/Managers/Game Handlers/ShopManager.cs
@@ -8,7 +8,7 @@ public class ShopManager : StaticInstance<ShopManager>
 {
 #region Members
 
-    [SerializeField] GameObject _salmonPrefab, _tunaPrefab;
+    [SerializeField] GameObject _salmonPrefab, _tunaPrefab , _riceCooker;
     [SerializeField] Transform _spawnpoint;
 
     [Header("Ingredient Prices")]
@@ -65,8 +65,6 @@ public class ShopManager : StaticInstance<ShopManager>
             SoundManager.Instance.PlaySound("select");
             StartCoroutine(ButtonCooldownTimer(0));
 
-            // waiting time for the salmon to spawn
-            StartCoroutine(DeliveryWaitTime());
             SpawnManager.Instance.SpawnVFX(VFXType.SMOKE, _spawnpoint, 2f);
             _orderBoxes.Add(SpawnManager.Instance.SpawnObject(_salmonPrefab, 
                                                               _spawnpoint, 
@@ -92,8 +90,6 @@ public class ShopManager : StaticInstance<ShopManager>
             GameManager.Instance.DeductMoney(_salmonPrice);
             UpatePlayerMoneyUI();
             
-            // waiting time before the salmon spawns
-            StartCoroutine(DeliveryWaitTime());
             SpawnManager.Instance.SpawnVFX(VFXType.SMOKE, _spawnpoint, 2f);
             SpawnManager.Instance.SpawnObject(_salmonPrefab,
                                               _spawnpoint.transform,                    
@@ -108,8 +104,6 @@ public class ShopManager : StaticInstance<ShopManager>
             SoundManager.Instance.PlaySound("select");
             StartCoroutine(ButtonCooldownTimer(1));
 
-            // waiting time for the tuna to spawn
-            StartCoroutine(DeliveryWaitTime());
             SpawnManager.Instance.SpawnVFX(VFXType.SMOKE, _spawnpoint, 2f);
             _orderBoxes.Add(SpawnManager.Instance.SpawnObject(_tunaPrefab, 
                                                               _spawnpoint, 
@@ -127,8 +121,6 @@ public class ShopManager : StaticInstance<ShopManager>
             GameManager.Instance.DeductMoney(_tunaPrice);
             UpatePlayerMoneyUI();           
             
-            // waiting time before the tuna spawns
-            StartCoroutine(DeliveryWaitTime());
             SpawnManager.Instance.SpawnVFX(VFXType.SMOKE, _spawnpoint, 2f);
             SpawnManager.Instance.SpawnObject(_tunaPrefab,
                                               _spawnpoint.transform,
@@ -137,7 +129,7 @@ public class ShopManager : StaticInstance<ShopManager>
     }
     public void BuyRice()
     {
-        if (_isTutorial) 
+        if (_isTutorial)
         {
             SoundManager.Instance.PlaySound("wrong");
             return;
@@ -145,18 +137,22 @@ public class ShopManager : StaticInstance<ShopManager>
 
         if (GameManager.Instance.CurrentPlayerMoney > 0)
         {
+            Debug.LogWarning($"Rice Ordered, Money remaining: {GameManager.Instance.CurrentPlayerMoney} ");
             // UX when the player has pressed the button
             SoundManager.Instance.PlaySound("select");
             StartCoroutine(ButtonCooldownTimer(2));
-            
+
             // deduction of money
             GameManager.Instance.DeductMoney(_ricePrice);
             UpatePlayerMoneyUI();
 
             // waiting time before the rice spawns
-            StartCoroutine(DeliveryWaitTime());
-
-            // insert code below to reset the Rice at the Rice Cooker
+            StartCoroutine(RiceDeliveryWaitTime());
+        }
+        else
+        {
+            SoundManager.Instance.PlaySound("wrong");
+            return;
         }
     }
 
@@ -188,9 +184,11 @@ public class ShopManager : StaticInstance<ShopManager>
         _interactableButtons[index].interactable = true;
     }
 
-    private IEnumerator DeliveryWaitTime()
+    private IEnumerator RiceDeliveryWaitTime()
     {
+        Debug.LogWarning("Rice has been ordered, please wait");
         yield return new WaitForSeconds(5f);
+        _riceCooker.GetComponentInChildren<RiceSpawn>().ResetRice();
     } 
 
 #endregion

--- a/OP_ChopChop!/Assets/_Scripts/Mechanics/Environment Mechanics/RiceSpawn.cs
+++ b/OP_ChopChop!/Assets/_Scripts/Mechanics/Environment Mechanics/RiceSpawn.cs
@@ -4,11 +4,14 @@ using UnityEngine;
 
 public class RiceSpawn : XRBaseInteractable
 {
-    [SerializeField] private GameObject _ricePrefab;
+    [SerializeField] private GameObject _ricePrefab , _riceMesh, _riceSpwnCollider;
     [SerializeField] private Transform _spawnpoint;
     [SerializeField] private bool _isTutorial;
+    [SerializeField] private float _decrementHeightCount;
 
+    private int _spawnCount;
     private bool _riceSpawned;
+    private Vector3 _riceSpwnColliderPos;
 
     protected override void OnEnable()
     {
@@ -27,15 +30,35 @@ public class RiceSpawn : XRBaseInteractable
             interactionManager = FindObjectOfType<XRInteractionManager>();
         
         _riceSpawned = false;
+        _spawnCount = 7;
+        _riceSpwnColliderPos = transform.position;
+    }
+
+    private void Update()
+    {
+        if(_spawnCount <= 0)
+        {
+            Debug.LogWarning($"Rice left: {_spawnCount}");
+            _riceMesh.gameObject.SetActive(false);
+        }
+    }
+
+    public void ResetRice()
+    {
+        _spawnCount = 7;
+        _riceMesh.gameObject.SetActive(true);
+        _riceMesh.gameObject.transform.localPosition = new Vector3(0,0,0);
+        _riceSpwnCollider.gameObject.transform.position = _riceSpwnColliderPos;
     }
 
     private void RiceEvent(SelectEnterEventArgs args)
     {
-        if (_riceSpawned) return;
+        Debug.LogWarning($"Rice left: {_spawnCount}");
+        if (_riceSpawned || _spawnCount <= 0) return;
 
         _riceSpawned = true;
 
-        GameObject newRice = _isTutorial ? 
+        GameObject newRice = _isTutorial ?
                              Instantiate(_ricePrefab, transform.position, transform.rotation) :
                              SpawnManager.Instance.SpawnObject(_ricePrefab, _spawnpoint,
                                                                SpawnObjectType.INGREDIENT);
@@ -45,6 +68,14 @@ public class RiceSpawn : XRBaseInteractable
 
         base.OnSelectEntered(args);
         StartCoroutine(ResetRiceSpawned());
+
+        if(!_isTutorial)
+        {
+            Debug.LogWarning("Decrement Not Running");
+            _spawnCount--;
+            _riceMesh.gameObject.transform.localPosition -= new Vector3(0, _decrementHeightCount, 0);
+            _riceSpwnCollider.gameObject.transform.localPosition -= new Vector3(0, _decrementHeightCount, 0);
+        }
     }
 
     private IEnumerator ResetRiceSpawned()

--- a/OP_ChopChop!/ProjectSettings/ProjectSettings.asset
+++ b/OP_ChopChop!/ProjectSettings/ProjectSettings.asset
@@ -525,7 +525,7 @@ PlayerSettings:
     m_APIs: 10000000
     m_Automatic: 1
   - m_BuildTarget: AndroidPlayer
-    m_APIs: 0b000000
+    m_APIs: 15000000
     m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16


### PR DESCRIPTION
ShopManager.CS
- renamed 'DeliveryWaitTime' Coroutine to 'RiceDeliveryWaitTime'
- calls rice reset from riceSpawn
- removed DeliveryWaitTime on BuySalmon and BuyTuna as it was not being used in the context
- added a GameObject reference to the rice cooker

RiceSpawn.CS
- added references for the rice mesh and rice collider
- added a spawncount int
- added a vector3 var for the starting position
- added a float for decrementHeightCount
- starting spawn count is 7
- Update checks if spawn count is 0. If yes, rice mesh is disabled
- Public ResetRice() function is added for ShopManager to call
- Rice event now decrements the height of the collider, mesh, and count based on the times it's activated

MainGameScene
- made necessary changes to avoid null references on the rice cooker and ordering screen
- minimized tp area to kitchen only
- tp area has been switched from deactivated to onSelectEntered (Grip)
- Rice cooker height is adjusted as it was clipping with the side table

Project Settings
- changed graphic api to vulkan

Features to test:
- Rice spawning and ordering
- Teleporting in MGS
- Faucet water if shader is now showing