### PR TITLE
0.63.2

### DIFF
--- a/OP_ChopChop!/Assets/OccAssets/OccAssets Prefabs/Equipment/Equipment/Rice Steamer/pf_RiceCooker.prefab
+++ b/OP_ChopChop!/Assets/OccAssets/OccAssets Prefabs/Equipment/Equipment/Rice Steamer/pf_RiceCooker.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   _spawnpoint: {fileID: 61382124886193506}
   _isTutorial: 0
   _decrementHeightCount: 0.01
-  _tutorialComponent: {fileID: 0}
+  _tutorialComponent: {fileID: 7171731960461472412}
 --- !u!54 &61382124886193519
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/OP_ChopChop!/Assets/Scenes/TrainingScene.unity
+++ b/OP_ChopChop!/Assets/Scenes/TrainingScene.unity
@@ -3794,6 +3794,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 4.1
       objectReference: {fileID: 0}
+    - target: {fileID: 5573612367992895046, guid: 5ab3e672be634b5419c451c218720ae4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 7269845803971795389, guid: 5ab3e672be634b5419c451c218720ae4,
         type: 3}
       propertyPath: m_IsTrigger
@@ -3803,42 +3808,10 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 5ab3e672be634b5419c451c218720ae4, type: 3}
 --- !u!4 &967904967 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2256566160567747343, guid: 5ab3e672be634b5419c451c218720ae4,
+  m_CorrespondingSourceObject: {fileID: 5573612367992895046, guid: 5ab3e672be634b5419c451c218720ae4,
     type: 3}
   m_PrefabInstance: {fileID: 967904966}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &967904968 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1448820265801652661, guid: 5ab3e672be634b5419c451c218720ae4,
-    type: 3}
-  m_PrefabInstance: {fileID: 967904966}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &967904969 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4878735974472268025, guid: 5ab3e672be634b5419c451c218720ae4,
-    type: 3}
-  m_PrefabInstance: {fileID: 967904966}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e3ee06c9707717d4b8b65aacf9694a98, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &967904970
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 967904968}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 565c6f2ef42812a42b1e12206e872c47, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _isInteractable: 0
-  _tutorialIndex: 3
 --- !u!1 &976028012
 GameObject:
   m_ObjectHideFlags: 0
@@ -5685,7 +5658,7 @@ MonoBehaviour:
   - {fileID: 1946015445}
   - {fileID: 1837609475}
   - {fileID: 1964793981}
-  - {fileID: 967904969}
+  - {fileID: 0}
   - {fileID: 997120328}
   - {fileID: 420081123}
   - {fileID: 2119257857}
@@ -5695,7 +5668,7 @@ MonoBehaviour:
   - {fileID: 1946015446}
   - {fileID: 1837609474}
   - {fileID: 26}
-  - {fileID: 967904970}
+  - {fileID: 2022151610}
   - {fileID: 997120329}
   - {fileID: 420081124}
   - {fileID: 2119257858}
@@ -8661,6 +8634,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2022151606}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2022151610 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7171731960461472412, guid: 5dd979da196494d4087777069c5aa1b5,
+    type: 3}
+  m_PrefabInstance: {fileID: 2022151606}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 565c6f2ef42812a42b1e12206e872c47, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2036382991
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/OP_ChopChop!/Assets/_Scripts/New Content/NEW_ColliderCheck.cs
+++ b/OP_ChopChop!/Assets/_Scripts/New Content/NEW_ColliderCheck.cs
@@ -62,17 +62,11 @@ public class NEW_ColliderCheck : MonoBehaviour
         NEW_Dish dish = other.gameObject.GetComponent<NEW_Dish>();
 
         // makes sure that you have both a PLATE & DISH script
-        if (dish == null)
+        if (dish != null && plate != null)
         {
-            Debug.LogError($"{other.name} has a Dish script");
-            SoundManager.Instance.PlaySound("wrong");
+            DoDishCollision(dish, plate);
+            Debug.Log("Finished dish collision!");
         }
-        else if (plate == null)
-        {
-            Debug.LogError($"{other.name} has a Plate script");
-            SoundManager.Instance.PlaySound("wrong");
-        }
-        else DoDishCollision(dish, plate);
     }
     private void OnDestroy() => 
         OnBoardingHandler.Instance.OnTutorialEnd -= DisableTutorial;
@@ -102,8 +96,9 @@ public class NEW_ColliderCheck : MonoBehaviour
         }
         else 
         {
+            SoundManager.Instance.PlaySound("wrong");
             SoundManager.Instance.PlaySound("ingredient order");
-            Debug.LogWarning("Player served a ingredient to the customer!");
+            Debug.LogError("Player served a ingredient to the customer!");
         }
     }
     private void DoDishCollision(NEW_Dish dish, NEW_Plate plate)
@@ -120,17 +115,20 @@ public class NEW_ColliderCheck : MonoBehaviour
     {
         if (dish.FoodCondition != FoodCondition.CLEAN)
         {
-            TriggerContainatedOrder();            
-            return;
+            TriggerContainatedOrder();  
+            Debug.LogError("Triggered dirty order!");         
         }
-        if (dish.DishPlatter != Order.WantedPlatter) 
-        {   
-            TriggerWrongOrder();            
-            return;
+        else if (dish.DishPlatter == Order.WantedPlatter) 
+        {
+            TriggerCorrectOrder(dish);
+            TriggerOnboarding();
+            Debug.LogWarning("Triggered correct order!");         
         }
-
-        TriggerCorrectOrder(dish);
-        TriggerOnboarding();
+        else
+        {
+            TriggerWrongOrder();                   
+            Debug.LogError("Triggered wrong order!");
+        }
     }
     private void TriggerContainatedOrder()
     {
@@ -180,9 +178,6 @@ public class NEW_ColliderCheck : MonoBehaviour
         {
             ShopManager.Instance.ClearList();
             Debug.LogWarning("Benny was served!");
-
-            // in case we find a timing defect for the onboarding
-            // DisableTutorial();
         }
         else Debug.LogWarning("Atrium was served!");
     }

--- a/OP_ChopChop!/Assets/_Scripts/New Content/NEW_TutorialComponent.cs
+++ b/OP_ChopChop!/Assets/_Scripts/New Content/NEW_TutorialComponent.cs
@@ -30,3 +30,139 @@ public class NEW_TutorialComponent : MonoBehaviour
     
     #endregion
 }
+
+/* public class OLD_ColliderCheck : MonoBehaviour 
+{
+    #region Members
+
+    public CustomerOrder Order { get; set; }
+
+    [SerializeField] private bool _isTutorial;
+    private Collider _collider;
+    private float _disableTimer;
+
+    [Header("Debugging")]
+    [SerializeField] private bool _isDevloperMode;
+
+    #endregion
+
+    #region Unity
+
+    private void Update()
+    {
+        if (!_isDevloperMode) return;
+
+        if (Input.GetKeyDown(KeyCode.Tab))
+        {
+            Debug.Log($"{this} wanted plater: {Order.WantedPlatter}");
+        }
+    }
+    private void OnTriggerEnter(Collider other)
+    {
+        if (Order == null)
+        {
+            Debug.LogError($"CustomerOrder is null!");
+            return;
+        }
+
+        if (other.gameObject.GetComponent<Ingredient>() != null)
+        {
+            // the player shouldn't get a Game Over in the tutorial
+            if (GameManager.Instance.CurrentShift == GameShift.Training)
+            {
+                Debug.LogError("Game over logic not possible in tutorial!");
+                return;
+            }
+
+            // starts the game over logic
+            Order.CustomerSR = 0f;
+            Destroy(other.gameObject);
+            StartCoroutine(CO_DisableCollider());
+            StartCoroutine(GameManager.Instance.CO_GameOver());
+            StartCoroutine(Random.value > 0.5f ? Order.CO_DirtyReaction() :
+                                                 Order.CO_AngryReaction());
+
+            // test debug to confirm all logic has worked
+            Debug.LogError("Served an INGREDIENT!");
+            return;
+        }
+
+        NEW_Plate plate = other.gameObject.GetComponent<NEW_Plate>();
+        NEW_Dish dish = other.gameObject.GetComponent<NEW_Dish>();
+
+        // makes sure that you have both a PLATE & DISH script
+        if (plate != null && dish != null)
+        {
+            DoDishCollision(dish); // customer's reaction when getting the dish
+
+            // visual cofirmation that the DISH was served 
+            dish.DisableDish(); // removes the food from the plate
+            plate.Served(); // increments the use counter & removed the food            
+
+            StartCoroutine(CO_DisableCollider()); // temporarily disables the collider
+        }
+        else
+        {
+            Debug.LogError($"{other.name} has a missing Plate or Dish script");
+            return;
+        }
+
+        if (_isTutorial)
+        {
+            OnBoardingHandler.Instance.AddOnboardingIndex();
+            OnBoardingHandler.Instance.PlayOnboarding();
+
+            if (Order.IsTunaCustomer)
+            {
+                ShopManager.Instance.ClearList();
+                Debug.LogWarning("Benny was served!");
+            }
+            else Debug.LogWarning("Atrium was served!");
+        }
+    }
+    private IEnumerator CO_DisableCollider()
+    {
+        _collider.enabled = false;
+        Debug.LogWarning("Collider disabled!");
+        yield return new WaitForSeconds(_disableTimer);
+
+        _collider.enabled = true;
+        Debug.LogWarning("Collider enabled!");
+
+        Order = null;
+        Debug.LogWarning("CustomerOrder is now null!");
+    }
+
+    #endregion
+
+    #region Helpers
+    
+    private void DoDishCollision(NEW_Dish dish)
+    {
+        if (dish.FoodCondition != FoodCondition.CLEAN)
+        {
+            Order.CustomerSR = 0f;
+            StartCoroutine(Order.CO_DirtyReaction());
+
+            Debug.LogWarning("Game Over!");
+        }
+        else if (dish.DishPlatter == Order.WantedPlatter)
+        {
+            Order.CustomerSR = (dish.Score + Order.PatienceRate) / 2f;
+            StartCoroutine(Order.CO_HappyReaction());
+
+            Debug.LogWarning("Happy reaction");
+        }
+        else
+        {
+            Order.CustomerSR = 0f;
+            StartCoroutine(Order.CO_AngryReaction());
+
+            Debug.LogWarning("Angy reaction");
+        }
+    }
+    public void DisableTutorial() => _isTutorial = false;
+    
+    #endregion
+}
+*/


### PR DESCRIPTION
[ColliderCheck]
- reverted the dish checker to use the July 13 version

[OnboardingHandler]
- added the correct reference for the Rice Cooker

[To Test]
- check if Atrium & Benny despawns after 1s when served the correct order
- check if MGS customers despawn after 1s when served the correct order
- check if Onboarding still plays when you serve a correct dish in MGS
- check if you have unli rice in TRS